### PR TITLE
Added schedule filling support

### DIFF
--- a/src/backfill.py
+++ b/src/backfill.py
@@ -4,7 +4,7 @@ import logging
 from util import database_util
 from util.basic import log_call_stack
 
-from web_api.game_logs import get_player_game_logs, get_team_game_logs
+from web_api.api import get_player_game_nodes, get_team_game_nodes
 
 now = datetime.datetime.utcnow()
 CURRENT_SEASON_YEAR = now.year if now.month > 8 else now.year - 1
@@ -32,22 +32,28 @@ def backfill_server(start_year=2007, end_year=CURRENT_SEASON_YEAR, update_bios=T
     for year in range(start_year, end_year):
 
         ## Get all the PlayerGameLogs and TeamGameLogs
-        player_game_logs = get_player_game_logs(year)
-        team_game_logs = get_team_game_logs(year)
+        player_game_nodes = get_player_game_nodes(year)
+        team_game_nodes = get_team_game_nodes(year)
 
         ## Add all the Players from this season to the database
-        database_util.create_and_save_all_player_records(player_game_logs, year, player_dict)
+        database_util.create_and_save_all_player_records(player_game_nodes, year, player_dict)
 
         ## Add all the PlayerGameLogs from this season to the database
-        database_util.create_and_save_all_player_game_log_records(player_game_logs)
+        database_util.create_and_save_all_player_game_log_records(player_game_nodes)
 
         ## Add all the TeamGameLogs from this season to the database
-        team_game_rosters = database_util.get_team_game_rosters(player_game_logs)
-        database_util.create_and_save_all_team_game_log_records(team_game_logs, team_game_rosters)
+        team_game_rosters = database_util.get_team_game_rosters(player_game_nodes)
+        database_util.create_and_save_all_team_game_log_records(team_game_nodes, team_game_rosters)
+
+        ## Add all the Schedues from this season to the database
+        database_util.create_and_save_all_schedule_records(team_game_nodes)
 
     ## Now, update current rosters and player biographical data
     database_util.update_rosters()
     database_util.update_player_bios(full_bio=update_bios)
+
+    ## And add the most recent schedules
+    database_util.create_and_save_2017_schedule_records()
 
 
 if __name__ == '__main__':

--- a/src/database/tables/league/schedules.py
+++ b/src/database/tables/league/schedules.py
@@ -14,6 +14,7 @@ class ScheduleRecord(DatabaseRecord):
 
     structure = {
         f.game_date      : s.game_date,
+        f.team_game_id   : s.team_game_id,
         f.game_id        : s.game_id,
         f.team_id        : s.team_id,
         f.is_home        : s.is_home,
@@ -29,6 +30,7 @@ class ScheduleRecord(DatabaseRecord):
 
     required_fields = [
         f.game_date,
+        f.team_game_id,
         f.game_id,
         f.team_id,
         f.is_home,

--- a/src/web_api/api.py
+++ b/src/web_api/api.py
@@ -1,12 +1,17 @@
+import json
+import requests
+
 import nba_py
 from nba_py import league as nba_py_league
 from nba_py import player as nba_py_player
 from nba_py import team as nba_py_team
 from nba_py.constants import TEAMS
 
+from web_api.parsers import get_game_date
 from web_api.nodes.gamenodes import PlayerGameNode, TeamGameNode
 from web_api.nodes.rosternodes import RosterNode
 from web_api.nodes.playernodes import ShortPlayerBioNode, LongPlayerBioNode
+from web_api.nodes.schedulenodes import ScheduleNode
 
 nba_py.HAS_PANDAS = False
 
@@ -60,4 +65,36 @@ Returns a JSON node containing player or team game logs from stats.nba.com
 def get_gamelog_json(year, player_or_team):
     season = '{}-{}'.format(year, str(year+1)[2:])
     return nba_py_league.GameLog(season=season, player_or_team=player_or_team).overall()
+
+
+
+"""
+Returns a list of 2017 schedule nodes
+"""
+def get_2017_schedule_nodes(skip_preseason, skip_regular_season, skip_postseason):
+
+    is_preseason      = lambda game_node : game_node['gid'].startswith('001')
+    is_regular_season = lambda game_node : game_node['gid'].startswith('002')
+    is_postseason     = lambda game_node : game_node['gid'].startswith('004')
+
+    nodes = []
+    url = 'https://data.nba.com/data/10s/v2015/json/mobile_teams/nba/2017/league/00_full_schedule_week.json'
+    nba_data = json.loads(requests.get(url).text)
+    for month_data in nba_data['lscd']:
+        for game_data in month_data['mscd']['g']:
+            if skip_preseason and is_preseason(game_data):
+                    continue
+            if skip_regular_season and is_regular_season(game_data):
+                    continue
+            if skip_postseason and is_postseason(game_data):
+                    continue
+            for (team, is_team_at_home) in [('h', True), ('v', False)]:
+                node = ScheduleNode(game_data)
+                node.game_date    = get_game_date(game_data, 'gdte')
+                node.game_id      = game_data['gid']
+                node.team_id      = int(game_data[team]['tid'])
+                node.team_game_id = str(str(node.team_id) + node.game_id)
+                node.is_home      = is_team_at_home
+                nodes.append(node)
+    return nodes
 

--- a/src/web_api/nodes/gamenodes.py
+++ b/src/web_api/nodes/gamenodes.py
@@ -1,6 +1,6 @@
 from database.tables.fields import Fields as f
 from web_api.nodes.basenode import BaseNode
-from web_api.parsers import cast_int, is_home, is_win, get_player_game_id, get_team_game_id
+from web_api.parsers import cast_int, is_home, is_win, get_player_game_id, get_team_game_id, get_game_date
 
 
 
@@ -58,6 +58,7 @@ class BaseGameNode(BaseNode):
             f.player_id      : cast_int,
             f.player_game_id : get_player_game_id,
             f.team_game_id   : get_team_game_id,
+            f.game_date      : get_game_date,
             f.roster         : lambda k, v : []
         }
         return

--- a/src/web_api/nodes/schedulenodes.py
+++ b/src/web_api/nodes/schedulenodes.py
@@ -1,0 +1,23 @@
+from database.tables.fields import Fields as f
+from web_api.nodes.basenode import BaseNode
+
+
+
+class ScheduleNode(BaseNode):
+
+    def __init__(self, nba_data):
+        self.attrs = {
+            f.game_date      : None,
+            f.game_id        : None,
+            f.team_id        : None,
+            f.team_game_id   : None,
+            f.is_home        : None,
+            f.game_log_saved : None,
+        }
+
+        self.parsers = {
+        }
+
+        self.init_attrs(nba_data)
+        return
+

--- a/src/web_api/parsers.py
+++ b/src/web_api/parsers.py
@@ -1,6 +1,8 @@
 import logging
+import datetime
 
 
+GAME_DATE_FORMATS = ['%Y-%m-%d']
 
 def get_gid_tid(nba_data):
     return (nba_data['GAME_ID'], nba_data['TEAM_ID'])
@@ -73,6 +75,17 @@ def get_dob(nba_data, nba_key):
         msg = 'Error parsing dob: {}'
         logging.warning(msg.format(nba_data[nba_key]))
         return None
+
+
+
+def get_game_date(nba_data, nba_key):
+    for date_format in GAME_DATE_FORMATS:
+        try:
+            date = datetime.datetime.strptime(str(nba_data[nba_key]), date_format)
+            return datetime.datetime.strftime(date, '%Y%m%d')
+        except:
+            continue
+        raise ValueError('No game date present for this node: {}'.format(nba_data))
 
 
 


### PR DESCRIPTION
Added support for filling the Schedule database table.  This will backfill old schedules and also fill in the schedule for the 2017 season.

TESTING DONE:
Manually tested the changes.  Both schedule functions adequately check to see if the records to-be-inserted already exist in the database (to avoid duplicate entries).  Unit tests soon to come.