### PR TITLE
HOTFIX: player bios weren't saving

### DIFF
--- a/src/util/database_util.py
+++ b/src/util/database_util.py
@@ -299,6 +299,7 @@ def update_player_bios(full_bio=False, reupdate_full_bios=False):
                 ## Set all the fields
                 for field in bio.attrs:
                     setattr(player_rec, field, getattr(bio, field))
+                player_rec.save()
 
                 ## Logging purposes only
                 counter_for_logging += 1


### PR DESCRIPTION
#83 

Player bios weren't saving into the database.  Added a fix that takes care of that issue.

Verified the correctness by looking at the database and seeing a few of these fields in the PlayerRecords (such as Country, draft year, etc...)