### PR TITLE
Removed blank games_lists from retired players

### DIFF
--- a/src/util/database_util.py
+++ b/src/util/database_util.py
@@ -120,9 +120,10 @@ def create_and_save_all_player_records(player_game_logs, year, player_dict=None)
     ## Sort each PlayerRecord's list of games
     ## and save this PlayerRecord into the database
     for player_rec in player_dict.values():
-        player_rec.games_dict[year_str] = sorted(set(player_rec.games_dict.get(year_str, [])))
-        player_rec.save()
-        logging.info('SAVED PLAYER to database: {}'.format(player_rec.player_id))
+        if player_rec.games_dict.get(year_str):
+            player_rec.games_dict[year_str] = sorted(set(player_rec.games_dict[year_str]))
+            player_rec.save()
+            logging.info('SAVED PLAYER to database: {}'.format(player_rec.player_id))
     return
 
 


### PR DESCRIPTION
#89 

Check the issue for a more detailed explanation of the problem.


Changes Made:
Before, all players were being given a empty list for a given season, regardless of whether or not they had games that year (old line 123).
Now, only players who played in a given year get a list of games.

Verified this with Isaiah Canaan.  Hasn't played any games in the 2017-2018 season, so his list in the dict is nonexistent (instead of empty)

player_id : 203477