### PR TITLE
Added partial bios for all players (not just current season)

### DIFF
--- a/src/backfill.py
+++ b/src/backfill.py
@@ -52,9 +52,9 @@ def backfill_server(start_year, end_year, add_missing_player_bios, update_all_pl
 
     ## Now, update current rosters and player biographical data
     database_util.update_rosters()
-    database_util.update_player_bios(
-                add_missing_player_bios=add_missing_player_bios,
-                update_all_player_bios=update_all_player_bios)
+    database_util.update_short_player_bios()
+    if add_missing_player_bios or update_all_player_bios:
+        database_util.update_long_player_bios(update_all_player_bios)
 
     ## And add the most recent schedules
     database_util.create_and_save_2017_schedule_records()

--- a/src/util/database_util.py
+++ b/src/util/database_util.py
@@ -265,7 +265,35 @@ def update_rosters():
 
 
 """
-Updates player biographical info.
+Updates some player biographical info.
+
+This is fast.  Sends one HTTP request and gets every player's
+name, player_id, and other fields.
+"""
+@log_call_stack
+def update_short_player_bios():
+
+    ## First, get all the player info from the web api
+    bio_dict = { node.player_id : node for node in get_all_short_player_bios() }
+
+    ## Now, for every player in the db, update their short bio
+    for player_rec in connection.PlayerRecord.find():
+
+        ## Get this player's bio
+        bio = bio_dict[player_rec.player_id]
+
+        ## Set all the fields
+        for field in bio.attrs:
+            setattr(player_rec, field, getattr(bio, field))
+
+        ## Save this record
+        player_rec.save()
+    return
+
+
+
+"""
+Updates all player biographical info.
 
 This is SLOW.  Each player requires a unique HTTP request
 to retrieve their data.  This only needs to be run once
@@ -273,40 +301,28 @@ every so often, such as at the end of a season or during
 initial database setup.
 """
 @log_call_stack
-def update_player_bios(add_missing_player_bios, update_all_player_bios):
+def update_long_player_bios(update_all_player_bios):
 
-    ## First, update name and draft year of active players
-    for bio in get_all_short_player_bios():
-        query = { f.player_id : bio.player_id }
-        player_rec = connection.PlayerRecord.one(query)
-        if player_rec is None:
-            player_rec = connection.PlayerRecord()
-            player_rec.player_id = bio.player_id
-        player_rec.player_name = bio.player_name
-        player_rec.first_year = bio.first_year
-        player_rec.save()
+    counter_for_logging = 0
+    for player_rec in connection.PlayerRecord.find():
 
-    ## Now, update as much biographical info as you can.
-    if add_missing_player_bios:
-        counter_for_logging = 0
-        for player_rec in connection.PlayerRecord.find():
+        ## If this player doesn't have their full bio,
+        ## or if you want to update it regardless, then do so:
+        if update_all_player_bios or not player_rec.has_bio:
+            bio = get_long_player_bio(player_rec.player_id)
 
-            ## If this player doesn't have their full bio,
-            ## or if you want to update it regardless, then do so:
-            if update_all_player_bios or not player_rec.has_bio:
-                bio = get_long_player_bio(player_rec.player_id)
+            ## Set all the fields
+            for field in bio.attrs:
+                setattr(player_rec, field, getattr(bio, field))
+                player_rec.has_bio = True
+            player_rec.save()
 
-                ## Set all the fields
-                for field in bio.attrs:
-                    setattr(player_rec, field, getattr(bio, field))
-                    player_rec.has_bio = True
-                player_rec.save()
-
-                ## Logging purposes only
-                counter_for_logging += 1
-                if counter_for_logging % 50 == 0:
-                    logging.info('Updated {} Player bios'.format(counter_for_logging))
-        logging.info('Updated {} Player bios in total'.format(counter_for_logging))
+            ## Logging purposes only
+            counter_for_logging += 1
+            if counter_for_logging % 50 == 0:
+                logging.info('Updated {} Player bios'.format(counter_for_logging))
+    logging.info('Updated {} Player bios in total'.format(counter_for_logging))
+    return
 
 
 
@@ -334,6 +350,7 @@ def create_and_save_all_schedule_records(team_game_nodes):
     if len(batch) > 0:
         num_saved_records = len(sched_table.insert(batch))
     logging.info('Updated {} ScheduleRecords.'.format(num_saved_records))
+    return
 
 
 

--- a/src/web_api/api.py
+++ b/src/web_api/api.py
@@ -21,7 +21,7 @@ nba_py.HAS_PANDAS = False
 Returns a list of ShortPlayerBioNodes
 """
 def get_all_short_player_bios():
-    return [ShortPlayerBioNode(datum) for datum in nba_py_player.PlayerList().info()]
+    return [ShortPlayerBioNode(datum) for datum in nba_py_player.PlayerList(only_current=0).info()]
 
 
 

--- a/src/web_api/nodes/playernodes.py
+++ b/src/web_api/nodes/playernodes.py
@@ -1,6 +1,6 @@
 from database.tables.fields import Fields as f
 from web_api.nodes.basenode import BaseNode
-from web_api.parsers import cast_int, get_height, get_dob
+from web_api.parsers import cast_int, get_height, get_dob, get_exp
 
 
 
@@ -11,11 +11,15 @@ class ShortPlayerBioNode(BaseNode):
             f.player_id   : 'PERSON_ID',
             f.player_name : 'DISPLAY_FIRST_LAST',
             f.first_year  : 'FROM_YEAR',
+            f.last_year   : 'TO_YEAR',
+            f.exp         : None,
         }
 
         self.parsers = {
             f.player_id  : cast_int,
             f.first_year : cast_int,
+            f.last_year  : cast_int,
+            f.exp        : get_exp,
         }
 
         self.init_attrs(nba_data)

--- a/src/web_api/parsers.py
+++ b/src/web_api/parsers.py
@@ -89,6 +89,16 @@ def get_game_date(nba_data, nba_key):
 
 
 
+def get_exp(nba_data, nba_key):
+    try:
+        return int(nba_data['TO_YEAR']) - int(nba_data['FROM_YEAR'])
+    except:
+        msg = 'Error parsing exp from nba_data: {}'.format(nba_data)
+        logging.warning(msg)
+        return None
+
+
+
 """
 Decorator for logging the call stack.
 Prints the name of the function, as well as the params


### PR DESCRIPTION
(1) Added partial bio support for all players (not just active players) #91 
(2) Separated short-bios from long-bios #92 

The short-bio now contains player_name, player_id, first_year, last_year, and exp.  It's also being populated for every player in the database, not just active players.

I also separated the bio-filling function into two separate ones: short-bio and long-bio

Tested this by running the backfill script.  Works as expected.