### PR TITLE
Fix bug where no teams are being displayed in filter.

### DIFF
--- a/src/util/players_util.py
+++ b/src/util/players_util.py
@@ -149,7 +149,9 @@ Returns a list team abbreviations.
 """
 def get_todays_games():
     today = date.today()
-    todays_date = str(today.year) + str(today.month) + str(today.day)
+    today_day  = str(today.day) if today.day > 9 else '0' + str(today.day)
+    today_month = str(today.month) if today.month > 9 else '0' + str(today.month)
+    todays_date = str(today.year) + today_month + today_day
     games = []
 
     todays_games = connection.NBAI.schedules.find({f.game_date : todays_date})


### PR DESCRIPTION
The date being sent to the database was being improperly formatted due to leading 0s on strings being removed as was happening in the previous bug with the table display.  This is the last place this formatting should affect any database requests.

Resolves #131 