### PR TITLE
Added convenience functions to DatabaseRecord class

### DIFF
--- a/src/database/tables/_base.py
+++ b/src/database/tables/_base.py
@@ -1,4 +1,5 @@
 import datetime
+from pymongo import MongoClient
 from mongokit import Document
 from database.connection import connection, DATABASE_NAME
 from database.tables.fields import Fields as f
@@ -31,8 +32,11 @@ class DatabaseRecord(Document):
 
     ## Updates the 'date_updated' timestamp
     def save(self):
+        return self.save_all([self])
+
+    ## Updates the 'date_updated' timestamp
+    def __update_timestamp(self):
         self[f.date_updated] = current_utctime()
-        super(DatabaseRecord, self).save()
         return
 
     ## Allows you to get fields directly,
@@ -45,8 +49,114 @@ class DatabaseRecord(Document):
     ## Allows you to set fields directly
     def __setattr__(self, field, value):
         if field in self.keys():
-            #if isinstance(value, basestring):
-            #    value = unicode(value)
             self[field] = value
         Document.__setattr__(self, field, value)
+
+    ## Returns a new Record with default values.
+    ## Allows you to create a new record using
+    ## FooRecord.new() instead of connection.FooRecord()
+    @classmethod
+    def new(cls, fields=None):
+        instance = getattr(connection, cls.__name__)()
+        if isinstance(fields, dict):
+            for k, v in fields.items():
+                instance[k] = v
+        return instance
+
+    ## Searches MongoDB for a specific Record.
+    ## Returns None if not present,
+    ## a Record if one exists,
+    ## or throws an exception if more than one exist
+    @classmethod
+    def find_one(cls, query):
+        not_an_instance = getattr(connection, cls.__name__)
+        return not_an_instance.one(query)
+
+    ## Searches MongoDB for a set of Records.
+    ## Returns a Cursor object containing zero or more objects
+    @classmethod
+    def find_all(cls, query=None):
+        if query is None:
+            query = {}
+        not_an_instance = getattr(connection, cls.__name__)
+        return not_an_instance.find(query)
+
+    ## Given a list of Records, saves all of them at once.
+    ## This will also populate the objects with ObjectIds and updated timestamps
+    @classmethod
+    def save_all(cls, document_list, uuid=False, safe=True, *args, **kwargs):
+
+        ## Returns a report
+        def report(inserted, updated):
+            return {"INSERTED" : inserted, "UPDATED" : updated}
+        
+        ## If there are no documents to save, exit.
+        if not document_list:
+            return report(0, 0)
+
+        ## Otherwise, create lists of documents to insert and update
+        insertable = []
+        updatable = []
+
+        ## For each document:
+        for rec in document_list:
+
+            ## Validate its type
+            for doc in document_list:
+                if not isinstance(rec, cls):
+                    raise ValueError("save_all expected a {} but got a {}".format(cls, type(rec)))
+
+            ## Validate its schema
+            rec.validate(auto_migrate=False)
+                
+            ## If this is an old item, just update the original
+            if '_id' in rec:
+                updatable.append(rec)
+                
+            ## Otherwise, create a new one
+            else:
+                if uuid:
+                    rec['_id'] = unicode("%s-%s" % (rec.__class__.__name__, uuid4()))
+                insertable.append(rec)
+                
+            ## Additional function calls present in the save method
+            rec._process_custom_type('bson', rec, rec.structure)
+            rec._process_custom_type('python', rec, rec.structure)
+        
+        ## Create an object representing this table
+        db = getattr(MongoClient(), DATABASE_NAME)
+        table = getattr(db, cls.__collection__)
+        
+        ## Validate that the primary keys are still unique
+        for primary_key in cls.indexes:
+            
+            ## If this key should be unique:
+            if primary_key['unique']:
+                
+                ## Then for each unique field:
+                for field in primary_key['fields']:
+                    
+                    ## Verify uniqueness among the records we're saving
+                    if len(document_list) != len(set([getattr(doc, field) for doc in document_list])):
+                        raise ValueError("Field {} should be unique".format(field))
+                    
+                    ## Make sure none of the new elements exist already
+                    query = { field : { '$in' : [getattr(doc, field) for doc in insertable] } }
+                    if table.find(query).count():
+                        raise ValueError("Field {} should be unique".format(field))
+        
+        ## Update all the timestamps
+        for doc in document_list:
+            doc.__update_timestamp()
+
+        ## Create a bulk operation to save everything at once
+        bulk_op = table.initialize_ordered_bulk_op()
+        for rec in insertable:
+            bulk_op.insert(rec)
+        for rec in updatable:
+            bulk_op.find({'_id' : rec._id}).update({'$set' : rec})
+
+        ## Save all the objects
+        d = bulk_op.execute()
+        return report(d['nInserted'], d['nModified'])
 


### PR DESCRIPTION
Added several functions to DatabaseRecord class to make life easier.

**Key features:**
- Bulk write operations: no more need to use ```pymongo``` syntax to save multiple items efficiently.  This functionality is built into the ```FooRecord``` classes now.
- Easier-to-use syntax for CRUD operations: Creating, finding, and updating objects is more intuitive (IMO) through the use of factory methods

**Functions Added**
```save_all(list_of_records)``` Saves all records at once
```new(optional_dict=None)``` Creates a new record, with the values in optional_dict if wanted
```find_one(query_dict)``` Returns None, a record, or throws an error
```find_all(query_dict)``` Returns a pymongo.Cursor object with zero or more records

Example Usage (aka, what's different):
```
from database.tables.league.players import PlayerRecord

############ This is the new stuff ############

## Creates a new PlayerRecord instance (default values)
rec = PlayerRecord.new()
print rec.player_id      ## prints None
print rec.player_name    ## prints None


## Creates a new PlayerRecord instance (some custom values)
lonzo = PlayerRecord.new({ f.player_name : "Lonzo Ball" })
print lonzo.player_id      ## prints None
print lonzo.player_name    ## prints "Lonzo Ball"


## Finds one PlayerRecord
bron = PlayerRecord.find_one({ f.player_id : 2544 })
returns_none = PlayerRecord.find_one({ f.player_id : -69 })
try:
    throws_error = PlayerRecord.find_one({ f.from_year : 2011 })
except:
    print "This found more than one, which isn't allowed here"


## Finds many PlayerRecords
cursor = PlayerRecord.find_all({ f.from_year : 2011 }) ## Finds a list of people drafted in 2011


## Saves one record.  Updates it's _id and timestamps
rec.save()

## Saves many records.  Updates all of their _ids and timestamps
records = [lonzo, bron]
status = PlayerRecord.save_all(records)
print status ## prints "{ 'INSERTED' : 1, 'UPDATED' : 1 }"



############ This is the old stuff ############
############ You can still do this ############

rec = connection.PlayerRecord()
rec = connection.PlayerRecord.one()
cursor = connection.PlayerRecord.find()
rec.save()
```

Testing done:
 - Made sure none of the preexisting code broke by running backfill 2x on an empty database.  Seems like it's working just fine (wishful thinking, I know)
 - Tested the new operations manually:
        - Did not let me save without required fields (Good)
        - Did not let me save with an invalid type (ex: player_id as a float) (Good)
        - Did not let me save one record with duplicate unique keys (Good)
        - Did not let me save multiple new records when the keys are in the DB (Good)